### PR TITLE
fix dart:web reference in filesystem.dart

### DIFF
--- a/file/filesystem/filesystem.dart
+++ b/file/filesystem/filesystem.dart
@@ -6,6 +6,7 @@
 // See: http://www.html5rocks.com/en/tutorials/file/filesystem/
 
 #import('dart:html');
+#import('package:htmlescape/htmlescape.dart');
 
 class FileSystemExample {
   DOMFileSystem _filesystem;
@@ -92,21 +93,6 @@ class FileSystemExample {
       _fileList.text = 'Directory emptied.';
     }, _handleError);
   }
-}
-
-/**
- * Escapes HTML-special characters of [text] so that the result can be
- * included verbatim in HTML source code, either in an element body or in an
- * attribute value.
- * 
- * In-lined from package:htmlescape/htmlescape.dart.
- */
-String htmlEscape(String text) {
-  return text.replaceAll("&", "&amp;")
-             .replaceAll("<", "&lt;")
-             .replaceAll(">", "&gt;")
-             .replaceAll('"', "&quot;")
-             .replaceAll("'", "&apos;");
 }
 
 void main() {

--- a/file/filesystem/pubspec.yaml
+++ b/file/filesystem/pubspec.yaml
@@ -1,0 +1,7 @@
+name: filesystem
+description: >
+ This is a port of "Exploring the FileSystem APIs" to Dart.
+ See: http://www.html5rocks.com/en/tutorials/file/filesystem/
+
+dependencies:
+  htmlescape: { sdk: htmlescape }


### PR DESCRIPTION
dart:web is no more - it's now package:htmlescape/htmlescape.dart.

This CL fixes the reference by inlining the one used method from that library. This is in lieu of doing a package import, adding a pubspec.yaml file, and requiring the user to run pub before trying the sample.
