### PR TITLE
fix(runtest): report errors even if pub get has not been run; and other improvements

### DIFF
--- a/dart_io_mini_samples/runtests.sh
+++ b/dart_io_mini_samples/runtests.sh
@@ -1,46 +1,70 @@
 #!/bin/bash
+#
+#------------------------------------------------------------------------------
 
-EXITSTATUS=0
+function usage() {
+    cat <<'EOM'
+
+Usage: runtests.sh [-q|+h|-h]
+
+  -h print this usage message.
+  +h report all hints as problems; otherwise only unused imports are counted
+     as problems.
+  -q quiet mode (only emit output if the analyzer finds problems). Verbose by
+     default.
+EOM
+}
+
+#------------------------------------------------------------------------------
+
+declare -i problem_count
+
+EXIT_STATUS=0
 PASSING=0
-WARNINGS=0
 FAILURES=0
+VERBOSE=1;
+BASE_DIR=$(dirname $0)
 
-echo "Running dartanalyzer on *.dart files"
+while [ $# -gt 0 ]; do
+    case $1 in
+	-h) usage; exit 0;;
+	+h) count_all_hints_as_problems=1;
+	    shift;;
+	-q) VERBOSE=;
+	    shift;;
+	-*) echo "Invalid option: $1";
+	    usage;
+	    exit 1;;
+    esac
+done
 
-for file in `find . -name "*dart"`
+[[ -n "$VERBOSE" ]] && echo "Running dartanalyzer on *.dart files in $BASE_DIR"
+
+for file in `find $BASE_DIR -name "*.dart"`
   do
-    echo $file
-    results=`dartanalyzer $file 2>&1`
+    [[ -n "$VERBOSE" ]] && echo $file
+    results=$(dartanalyzer $file 2>&1)
+    problem_count=$(echo "$results" | grep -E "^\[(error|warning)\]" | wc -l)
 
-    # hints such as 'Unused import' should be treated as warnings.
-    if [[ "$results" == *\[hint\]* ]]; then
-      echo "$results"
-      let WARNINGS++
-      EXITSTATUS=1
-    fi
-
-    exit_code=$?
-    if [ $exit_code -eq 2 ]; then
-      let FAILURES++
-      EXITSTATUS=1
-    elif [ $exit_code -eq 1 ]; then
-      let WARNINGS++
-      EXITSTATUS=1
-    elif [ $exit_code -eq 0 ]; then
-      let PASSING++
+    if [[ -n "$count_all_hints_as_problems" ]]; then
+	problem_count+=$(echo "$results" | grep -E "^\[hint\]" | wc -l)
     else
-      echo "$file: Unknown exit code: $exit_code."
+	# hints such as 'Unused import' should be treated as warnings.
+	problem_count+=$(echo "$results" | grep -E "^\[hint\] Unused import" | wc -l)
     fi
-    # Remove the output directory so that subsequent test runs will still see
-    # the warnings and errors.
-    rm -rf out/
+
+    if [ "$problem_count" -gt 0 ]; then
+	echo "$results"
+	EXIT_STATUS=1
+	let FAILURES++
+    else
+	let PASSING++	
+    fi;
   done
 
-echo
-echo "-------------------------------------------------------------------------"
-echo "PASSING = $PASSING"
-echo "WARNINGS = $WARNINGS"
-echo "FAILURES = $FAILURES"
-echo "-------------------------------------------------------------------------"
-echo
-exit $EXITSTATUS
+if [[ -n "$VERBOSE" || "$FAILURES" -gt 0 ]]; then
+    echo "-------------------------------------------------------------------"
+    echo "$PASSING PASSED, $FAILURES FAILED "
+    echo "-------------------------------------------------------------------"
+fi
+exit $EXIT_STATUS


### PR DESCRIPTION
- Fixes problem of all tests passing when there is no `packages` folder.
- Command line option `+h` can be used to report all hints.
- Added `-q` for quiet mode.
