### PR TITLE
misspelled link update.

### DIFF
--- a/html5/web/websockets/basics/README.md
+++ b/html5/web/websockets/basics/README.md
@@ -15,6 +15,6 @@ response on the web page.
 
 You can open the example in Dart Editor and run it by clicking `index.html`.
 Or, you can try this
-[live demo](http://www.dartlang.org/samples/websocket/).
+[live demo](http://www.dartlang.org/samples/websockets/).
 
 Please report any [bugs or feature requests](http://dartbug.com/new).


### PR DESCRIPTION
added s to [live demo](http://www.dartlang.org/samples/websocket/). as it was a broken link.
