### PR TITLE
Fixed rename example

### DIFF
--- a/dart_io_mini_samples/example/files_directories_and_symlinks/renaming_a_file_directory_or_symlink.dart
+++ b/dart_io_mini_samples/example/files_directories_and_symlinks/renaming_a_file_directory_or_symlink.dart
@@ -19,8 +19,8 @@ main() async {
   print('The path is ${file.path}');
 
   // Rename the file.
-  await file.rename('${systemTempDir.path}/bar.txt');
+  var newFile = await file.rename('${systemTempDir.path}/bar.txt');
 
   // Prints path ending with `bar.txt`.
-  print('The path is ${file.path}');
+  print('The path is ${newFile.path}');
 }


### PR DESCRIPTION
The example treats `rename` as if it modifies the existing `File` object, while it actually returns a new `File` instance with the changes. I modified the example to get the new file name correctly.